### PR TITLE
Use hiptest-publisher from CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM ruby:2.2-onbuild
 RUN chmod 777 .
 RUN rake install
+WORKDIR /app
+VOLUME /app
+ENTRYPOINT ["hiptest-publisher"]

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,5 @@ docker-image :
 	docker build -t $(DOCKER_IMAGE) .
 
 test : docker-image
-	docker run --interactive --tty --user $$UID --rm $(DOCKER_IMAGE) bundle exec rspec
+	docker run --interactive --tty --user $$UID --rm \
+	  --workdir "/usr/src/app" --entrypoint bundle $(DOCKER_IMAGE) exec rspec

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ Hiptest Publisher
 Installing
 ----------
 
+### Docker Installation
+
+You can build the docker image or use an already built docker image for unitive/hiptest-publisher.
+
+You can use the docker image just like the command line installation. The image includes a script that runs
+docker with the necessary options. Copy the script from the image using these commands:
+
+```shell
+cid=$(docker create unitive/hiptest-publisher) &&
+docker cp $cid:/usr/src/app/bin/hiptest-publisher.sh hiptest-publisher &&
+docker rm $cid > /dev/null
+```
+
+Now you can use `hiptest-publisher` in order to run the program. 
+
+Suggestions for installation of the hiptest-publisher script:
+
+* Copy hiptest-publisher to a path directory (e.g. ~/bin or /usr/local/bin).
+* Create an alias for hiptest-publisher: `alias 'hiptest-publisher=/path/to/hiptest-publisher'`
+
+### Local Installation
+
 You need to have [Ruby installed on your machine](https://www.ruby-lang.org/en/installation/). You can then install it using gem:
 
 ```shell

--- a/bin/hiptest-publisher.sh
+++ b/bin/hiptest-publisher.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker run --interactive --tty --rm --user $UID --volume $(pwd):/app unitive/hiptest-publisher  "$@"


### PR DESCRIPTION
We should be able to use the hiptest-publisher docker container as if we were running hiptest-publisher locally.

The changes to the Dockerfile allow hiptest-publisher to appear to run locally. The hiptest-publisher.sh script is used to represent the local hiptest-publisher command.

Now I can `hiptest-publisher --config-file file.config` as if hiptest-publisher was installed on my system.

@damonomad for a double check.
